### PR TITLE
Enable mobile tap interactions for iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     </div>
   </div>
 
-  <audio id="bgm" src="sounds/bgm.mp3" loop></audio>
+    <audio id="bgm" src="sounds/bgm.mp3" loop playsinline preload="auto"></audio>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -628,14 +628,26 @@ function closeStoryModal() {
     }
 }
 
+function addTapListener(element, handler) {
+    element.addEventListener('click', handler);
+    element.addEventListener(
+        'touchstart',
+        e => {
+            e.preventDefault();
+            handler(e);
+        },
+        { passive: false }
+    );
+}
+
 // ==== イベントリスナー ====
 DOM.characters.forEach((char, i) => {
-    char.addEventListener('click', () => selectCharacter(i));
+    addTapListener(char, () => selectCharacter(i));
 });
 
-DOM.nextButton.addEventListener('click', nextLevel);
+addTapListener(DOM.nextButton, nextLevel);
 
-DOM.resetButton.addEventListener('click', () => {
+addTapListener(DOM.resetButton, () => {
     if (gameState.gameCompleted) {
         showGameOver();
     } else {
@@ -644,7 +656,7 @@ DOM.resetButton.addEventListener('click', () => {
     }
 });
 
-DOM.restartButton.addEventListener('click', () => {
+addTapListener(DOM.restartButton, () => {
     DOM.gameOverArea.style.display = 'none';
     DOM.characterSelection.style.display = 'block';
     DOM.amidakujiArea.style.display = 'block';


### PR DESCRIPTION
## Summary
- Allow inline background music playback in mobile Safari
- Add touch event listeners so gameplay works on iPhone

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c023ccb07883308dbb9385c757503b